### PR TITLE
Bug in the computation of 'currentdate' for diag_name_post

### DIFF
--- a/scripts/4.run_post.bash
+++ b/scripts/4.run_post.bash
@@ -215,7 +215,7 @@ for ii in \$(seq  ${inicio} ${fim})
 do
    i=\$(printf "%04d" \${ii})
    hh=${YYYYMMDDHHi:8:2}
-   currentdate=\$(date -d "${YYYYMMDDHHi:0:8} \${hh}:00 \$(echo "(\${i}-1)*3" | bc) hours" +"%Y%m%d%H")
+   currentdate=\$(date -d "${YYYYMMDDHHi:0:8} \${hh}:00 \$(echo "(\${i}-1)*${t_strout:0:2}" | bc) hours" +"%Y%m%d%H")
    diag_name_post=MONAN_DIAG_G_POS_${EXP}_${YYYYMMDDHHi}_\${currentdate}.00.00.x${RES}L${NLEV}.nc
    
    cd ${DIRRUN}/dir.\${i}


### PR DESCRIPTION
Correcting a bug in the computation of 'currentdate' variable used as… interfix for diagnostic post processed file (diag_name_post)

-   currentdate=\$(date -d "${YYYYMMDDHHi:0:8} \${hh}:00 \$(echo "(\${i}-1)*3" | bc) hours" +"%Y%m%d%H")
+   currentdate=\$(date -d "${YYYYMMDDHHi:0:8} \${hh}:00 \$(echo "(\${i}-1)*${t_strout:0:2}" | bc) hours" +"%Y%m%d%H")
    diag_name_post=MONAN_DIAG_G_POS_${EXP}_${YYYYMMDDHHi}_\${currentdate}.00.00.x${RES}L${NLEV}.nc
